### PR TITLE
Fix code scanning alert no. 5: SQL query built from user-controlled sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,8 +19,8 @@ conn = init_db()
 def get_user():
    user_id = request.args.get('id')
    cursor = conn.cursor()
-   # Introducing SQL Injection vulnerability
-   cursor.execute(f"SELECT name FROM user WHERE id = {user_id}")
+   # Use parameterized query to prevent SQL Injection
+   cursor.execute("SELECT name FROM user WHERE id = ?", (user_id,))
    user = cursor.fetchone()
    if user:
        return f"User: {user[0]}"


### PR DESCRIPTION
Fixes [https://github.com/ghas-bootcamp-2024-11-13-cloudlabs680/ghas-bootcamp-python/security/code-scanning/5](https://github.com/ghas-bootcamp-2024-11-13-cloudlabs680/ghas-bootcamp-python/security/code-scanning/5)

To fix the problem, we need to use parameterized queries instead of directly incorporating user input into the SQL query string. Parameterized queries ensure that user input is properly escaped and treated as data rather than executable code.

The best way to fix the problem without changing existing functionality is to modify the `cursor.execute` call to use a parameterized query. This involves replacing the f-string with a query that uses placeholders and passing the user input as a parameter to the `execute` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
